### PR TITLE
Remove unnecessary call to componentDidMount

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -38,7 +38,6 @@ describe('testing <App />', () => {
     };
     signIn.mockReturnValue(Promise.resolve(user));
     const wrapper = await mount(<App />);
-    await wrapper.instance().componentDidMount();
     wrapper.update();
     expect(wrapper.containsMatchingElement(<LoggedInHomePage />)).toBeTruthy();
     expect(wrapper.containsMatchingElement(<PublicHomePage />)).toBeFalsy();


### PR DESCRIPTION
It looks like componentDidMount is getting called when we call
mount(<App />), so there is no need to have a separate awaited call to
mount.instance().componentDidMount().

madliberation-50